### PR TITLE
Improve generic run support.

### DIFF
--- a/blueprint/opm/local-blueprint-inputs-example.yaml
+++ b/blueprint/opm/local-blueprint-inputs-example.yaml
@@ -25,3 +25,25 @@ sze_config:
         password: "[PASS]"
     country_tz: "Europe/Budapest"
     workload_manager: "SLURM"
+
+
+
+#############################
+# Application specific inputs
+#############################
+
+# Number of parallel processes to use for the run (all on a single node)
+parallel_tasks: 1
+
+# Max time allowed
+max_time: '00:05'
+
+# URL for input files.
+# They are expected to be in a gzip-ed tarball, say 'case.tgz'.
+# That must unpack into a directory with the same name, in this example: 'case'.
+# That directory again is expected to contain a *single* .DATA file, that file will be
+# the one passed to the simulator.
+#
+# The URLs below point to archives with the spe1 and Norne cases, respectively.
+input_url: 'https://gitlab.srv.cesga.es/atgeirr/OPM-public-testing-data/raw/master/spe1.tgz'
+#input_url: 'https://gitlab.srv.cesga.es/atgeirr/OPM-public-testing-data/raw/master/norne.tgz'

--- a/blueprint/opm/run-flow-generic/scripts/singularity_bootstrap_run-flow-generic.sh
+++ b/blueprint/opm/run-flow-generic/scripts/singularity_bootstrap_run-flow-generic.sh
@@ -5,7 +5,11 @@ REMOTE_URL=$2
 
 cd $WORKDIR
 wget $REMOTE_URL
+ARCHIVE=$(basename $REMOTE_URL)
+tar zxvf $ARCHIVE
+DIRNAME=$(basename $ARCHIVE .tgz)
+DECK=$(ls $DIRNAME/*.DATA)
 cat << EOF > run_generated.param
-deck_filename=$(readlink -m $WORKDIR)/$(basename $REMOTE_URL)
+deck_filename=$(readlink -m $WORKDIR)/$DECK
 EOF
 

--- a/blueprint/opm/run-flow-generic/scripts/singularity_revert_run-flow-generic.sh
+++ b/blueprint/opm/run-flow-generic/scripts/singularity_revert_run-flow-generic.sh
@@ -4,5 +4,8 @@ WORKDIR=$1
 REMOTE_URL=$2
 
 cd $WORKDIR
-rm $(basename $REMOTE_URL)
-EOF
+ARCHIVE=$(basename $REMOTE_URL)
+rm $ARCHIVE
+DIRNAME=$(basename $ARCHIVE .tgz)
+rm -r $DIRNAME
+rm run_generated.param


### PR DESCRIPTION
Now the input URL is expected to be a tarball containing the case files, rather than being a single case file. This allows us to run for example the SPE1 and Norne cases with identical Tosca setup.

Only affects OPM, will self-merge.